### PR TITLE
Small improvements to page description metadata

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,156 @@
+{% comment %}
+Changes relative to the default header:
+- markdownify the page content when generating the description
+{% endcomment -%}
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    {% capture title %}
+      {%- if page.share-title -%}
+        {{ page.share-title | strip_html | xml_escape }}
+      {%- elsif page.title -%}
+        {{ page.title | strip_html | xml_escape  }}
+      {%- else -%}
+        {{ site.title | strip_html | xml_escape }}
+      {%- endif -%}
+    {% endcapture %}
+
+    {% capture description %}
+      {%- if page.share-description -%}
+        {{ page.share-description | strip_html | xml_escape }}
+      {%- elsif page.subtitle -%}
+        {{ page.subtitle | strip_html | xml_escape }}
+      {%- else -%}
+        {%- assign excerpt_length = site.excerpt_length | default: 50 -%}
+        {{ page.content | markdownify | strip_html | xml_escape | truncatewords: excerpt_length | strip }}
+      {%- endif -%}
+    {% endcapture %}
+
+    <title>{{ title }}</title>
+
+    {% if site.author %}
+    <meta name="author" content="{{ site.author }}">
+    {% endif %}
+
+    <meta name="description" content="{{ description }}">
+
+    {% if site.mobile-theme-col %}
+    <meta name="theme-color" content="{{ site.mobile-theme-col }}">
+    {% endif %}
+
+    {% if site.keywords %}
+    <meta name="keywords" content="{{ site.keywords }}">
+    {% endif %}
+
+    {% if site.rss-description %}
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | absolute_url }}">
+    {% endif %}
+
+    {% include gtag.html %}
+    {% include gtm_head.html %}
+    {% include google_analytics.html %}
+    {% include cloudflare_analytics.html %}
+
+    {% if layout.common-ext-css %}
+      {% for css in layout.common-ext-css %}
+        {% include ext-css.html css=css %}
+      {% endfor %}
+    {% endif %}
+
+    {% if layout.common-css %}
+      {% for css in layout.common-css %}
+        <link rel="stylesheet" href="{{ css | relative_url }}">
+      {% endfor %}
+    {% endif %}
+
+    {% if site.site-css %}
+      {% for css in site.site-css %}
+        <link rel="stylesheet" href="{{ css | relative_url }}">
+      {% endfor %}
+    {% endif %}
+
+    {% if page.ext-css %}
+      {% for css in page.ext-css %}
+        {% include ext-css.html css=css %}
+      {% endfor %}
+    {% endif %}
+
+    {% if page.css %}
+      {% for css in page.css %}
+        <link rel="stylesheet" href="{{ css | relative_url }}">
+      {% endfor %}
+    {% endif %}
+
+    {% if site.fb_app_id %}
+    <meta property="fb:app_id" content="{{ site.fb_app_id }}">
+    {% endif %}
+
+    {% if site.title %}
+    <meta property="og:site_name" content="{{ site.title }}">
+    {% endif %}
+
+    {%- capture img -%}
+      {%- if page.share-img -%}
+        {{ page.share-img }}
+      {%- elsif page.cover-img -%}
+        {%- if page.cover-img.first -%}
+          {{ page.cover-img[0].first.first }}
+        {%- else -%}
+          {{ page.cover-img }}
+        {%- endif -%}
+      {%- elsif page.thumbnail-img -%}
+        {{ page.thumbnail-img }}
+      {%- elsif site.avatar -%}
+        {{ site.avatar }}
+      {% endif %}
+    {%- endcapture -%}
+    {%- assign img=img | strip -%}
+
+    <meta property="og:title" content="{{ title }}">
+    <meta property="og:description" content="{{ description }}">
+
+    {% if img != "" %}
+    <meta property="og:image" content="{{ img | absolute_url }}">
+    {% endif %}
+
+    {% if page.id %}
+    <meta property="og:type" content="article">
+    <meta property="og:article:author" content="{{ site.author }}">
+    <meta property="og:article:published_time" content="{{ page.date | date_to_xmlschema }}">
+    <meta property="og:url" content="{{ page.url | absolute_url }}">
+    <link rel="canonical" href="{{ page.url | absolute_url }}">
+    {% else %}
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ page.url | absolute_url | strip_index }}">
+    <link rel="canonical" href="{{ page.url | absolute_url | strip_index }}">
+    {% endif %}
+
+    {% if img != "" and img != site.avatar %}
+    <meta name="twitter:card" content="summary_large_image">
+    {% else %}
+    <meta name="twitter:card" content="summary">
+    {% endif %}
+    <meta name="twitter:site" content="@{{ site.social-network-links.twitter }}">
+    <meta name="twitter:creator" content="@{{ site.social-network-links.twitter }}">
+
+    <meta property="twitter:title" content="{{ title }}">
+    <meta property="twitter:description" content="{{ description }}">
+
+    {% if img != "" %}
+    <meta name="twitter:image" content="{{ img | absolute_url }}">
+    {% endif %}
+
+    {% include matomo.html %}
+
+    {% if page.comments and site.staticman.repository and site.staticman.branch %}
+    <link rel="stylesheet" href="{{ "/assets/css/staticman.css" | relative_url }}">
+    {% endif %}
+
+    {% if page.head-extra %}
+      {% for file in page.head-extra %}
+        {% include {{ file }} %}
+      {% endfor %}
+    {% endif %}
+
+  </head>

--- a/documentation/admin/installation/ingestor.md
+++ b/documentation/admin/installation/ingestor.md
@@ -2,6 +2,7 @@
 layout: page
 title: Ingestor Installation
 permalink: /documentation/admin/installation/ingestor
+share-description: Instructions for installing the ingestor for OpenEM
 ---
 
 ## Download and build the ingestor
@@ -20,7 +21,7 @@ permalink: /documentation/admin/installation/ingestor
 {: .box-note}
 **Note:** Additional information can be found [here](https://github.com/SwissOpenEM/Ingestor/blob/main/configs/ReadMe.md)
 
-Run the following command: 
+Run the following command:
 
 ```bash
 cp [REPO_DIR]/configs/openem-ingestor-config.yaml [REPO_DIR]/cmd/openem-ingestor-service/build/openem-ingestor-config.yaml
@@ -68,8 +69,8 @@ Transfer:
 
 Important options to customize:
  - **Transfer.Globus.ClientID**: this should be set to the same client-id as the one you'll use in the next paragraph. You need to create a new client on `app.globus.org`, please check out the [following page]() for more information
- - **Transfer.Globus.RefreshToken**: this a refresh token that you get from Globus by requesting offline access. 
- It is a temporary solution. You can use the tool [here](https://github.com/SwissOpenEM/globus) to obtain one. 
+ - **Transfer.Globus.RefreshToken**: this a refresh token that you get from Globus by requesting offline access.
+ It is a temporary solution. You can use the tool [here](https://github.com/SwissOpenEM/globus) to obtain one.
  First compile the go application under `cmd/` by running `go build . -o globus`, then use the following command:
  ```bash
  ./globus getRefreshToken --client-id "client-id-here" --auth-code-grant=true --redirect-url="https://auth.globus.org/v2/web/auth-code" --src-endpoint "(optional) source-collection-id" --dest-endpoint "(optional) dest-collection-id"
@@ -137,6 +138,7 @@ WebServer:
 
 ### Metadata Extractors
 Example config:
+
 ```yaml
 ...
 MetadataExtractors:
@@ -150,9 +152,9 @@ MetadataExtractors:
     GithubProject: LS_Metadata_reader
     Version: v0.2.8
     Executable: LS_Metadata_reader
-    Checksum: e8a2abc7a0d8759edf4559e27879b7977000a868a2f7d39b7804ff5e5c0d1559 
+    Checksum: e8a2abc7a0d8759edf4559e27879b7977000a868a2f7d39b7804ff5e5c0d1559
     ChecksumAlg: sha256
-    CommandLineTemplate: "-i '{{.SourceFolder}}' -o '{{.OutputFile}}'"
+    {% raw -%}CommandLineTemplate: "-i '{{.SourceFolder}}' -o '{{.OutputFile}}'"{% endraw %}
     Methods:
       - Name: Single Particle
         Schema: oscem_schemas.schema.json
@@ -164,6 +166,7 @@ MetadataExtractors:
         Schema: oscem_env_tomo.json
 ...
 ```
+
  - **InstallationPath** determines where the extractors should be downloaded/installed.
  - **SchemasLocation** determines where the schemas for extractors reside.
  - **DownloadMissingExtractors** sets whether to download extractors automatically from github

--- a/index.md
+++ b/index.md
@@ -1,18 +1,20 @@
 ---
 layout: home
 title: Open Electron Microscopy Data Network
-tags: 
+tags:
   - OpenEM
   - Electron microscopy
   - Research data
   - Project updates
   - Scientific collaboration
+share-description: |-
+  The Open EM Data Network (OpenEM) is a consortium of Swiss electron microscopy facilities working together to implement FAIR and open research data.
 ---
 
 
 Welcome to the OpenEM project website. Our goal is to simplify the work with electron microscopy data and to support research. Here you will find current information on the project and its progress. Technical documentation and information on project participation will also be made available here in the future.
 
-If you are interested or have any feedback, please contact us. 
+If you are interested or have any feedback, please contact us.
 
 <html>
 <br>


### PR DESCRIPTION
The `share-description` metadata is used as the page summary for search engines, link previews, etc.

- add a description to the front page
- Pages without a description use HTML for the excerpt rather than raw markdown
- Some minor fixes to the ingestor docs